### PR TITLE
feat: Add logging framework

### DIFF
--- a/docs/advanced/logging.md
+++ b/docs/advanced/logging.md
@@ -1,0 +1,45 @@
+# Logging and Telemetry
+
+The `llama-prompt-ops` library includes a flexible logging framework to provide insights into the optimization process. You can control the verbosity of the output and export detailed telemetry for analysis.
+
+## Configuring Log Levels
+
+You can configure the logging level in two ways:
+
+1.  **Via the command-line interface:**
+
+    Use the `--log-level` option when running the `migrate` command:
+
+    ```bash
+    llama-prompt-ops migrate --config your_config.yaml --log-level DEBUG
+    ```
+
+    Available log levels are `DEBUG`, `INFO`, `WARNING`, `ERROR`, and `CRITICAL`.
+
+2.  **Via the YAML configuration file:**
+
+    Add a `logging` section to your `config.yaml` file:
+
+    ```yaml
+    logging:
+      level: DEBUG
+    ```
+
+    The command-line option will override the setting in the configuration file.
+
+## Exporting Telemetry
+
+The logging framework can capture detailed timings and metrics during the optimization process and export them to a JSON file. To enable this, add an `export_path` to the `logging` section of your configuration file:
+
+```yaml
+logging:
+  level: INFO
+  export_path: "results/telemetry_${TIMESTAMP}.json"
+```
+
+The `${TIMESTAMP}` placeholder will be replaced with a timestamp of the format `YYYYMMDD_HHMMSS`.
+
+The exported JSON file will contain two main sections:
+
+-   `timings`: The duration of each major phase of the optimization process.
+-   `metrics`: A list of metrics logged during the process, including the metric key, value, and step.

--- a/src/llama_prompt_ops/core/model.py
+++ b/src/llama_prompt_ops/core/model.py
@@ -15,6 +15,8 @@ import os
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional, Union
 
+from .utils.logging import get_logger
+
 try:
     import dspy
 
@@ -375,12 +377,13 @@ def setup_model(model_name=None, adapter_type="dspy", **kwargs):
         response = adapter.generate_with_chat_format(messages)
     """
     # Create adapter based on type
+    logger = get_logger()
     if adapter_type.lower() == "dspy":
         # For DSPy, rename model_name to match the expected parameter
         if model_name and "model_name" not in kwargs:
             kwargs["model_name"] = model_name
         adapter = DSPyModelAdapter(**kwargs)
-        print(
+        logger.progress(
             f" Using model with DSPy: {kwargs.get('model_name', 'custom configuration')}"
         )
     elif adapter_type.lower() == "textgrad":
@@ -388,7 +391,7 @@ def setup_model(model_name=None, adapter_type="dspy", **kwargs):
         if model_name and "model_name" not in kwargs:
             kwargs["model_name"] = model_name
         adapter = TextGradModelAdapter(**kwargs)
-        print(
+        logger.progress(
             f" Using model with TextGrad: {kwargs.get('model_name', 'custom configuration')}"
         )
     else:

--- a/src/llama_prompt_ops/core/prompt_processors.py
+++ b/src/llama_prompt_ops/core/prompt_processors.py
@@ -17,6 +17,7 @@ from .utils.llama_utils import (
     get_task_type_from_prompt,
     select_instruction_preference,
 )
+from .utils.logging import get_logger
 
 
 class PromptProcessor:
@@ -132,6 +133,7 @@ class InstructionPreference(PromptProcessor):
         """
         super().__init__(next_processor)
         self.verbose = verbose
+        self.logger = get_logger()
 
     def process(self, data: Dict[str, Any]) -> Dict[str, Any]:
         """
@@ -174,9 +176,11 @@ class InstructionPreference(PromptProcessor):
 
             # Log the task type and selected preferences if verbose
             if self.verbose:
-                print(f"Task type detected: {task_type}")
+                self.logger.progress(f"Task type detected: {task_type}")
                 for i, pref in enumerate(selected_preferences):
-                    print(f"Selected instruction preference {i+1}: {pref[:50]}...")
+                    self.logger.progress(
+                        f"Selected instruction preference {i+1}: {pref[:50]}..."
+                    )
 
         # Pass to the next processor
         return super().process(data)

--- a/src/llama_prompt_ops/core/utils/__init__.py
+++ b/src/llama_prompt_ops/core/utils/__init__.py
@@ -8,10 +8,12 @@ Utility modules for prompt optimization.
 """
 
 from .format_utils import convert_json_to_yaml, json_to_yaml_file
+from .logging import get_logger
 from .strategy_utils import map_auto_mode_to_dspy
 
 __all__ = [
     "map_auto_mode_to_dspy",
     "convert_json_to_yaml",
     "json_to_yaml_file",
+    "get_logger",
 ]

--- a/src/llama_prompt_ops/core/utils/logging.py
+++ b/src/llama_prompt_ops/core/utils/logging.py
@@ -1,0 +1,81 @@
+import atexit
+import json
+import logging
+import os
+import time
+from contextlib import contextmanager
+
+_LOG_SINGLETON: "LoggingManager|None" = None
+
+DEFAULT_LEVEL = os.getenv("PROMPT_OPS_LOG_LEVEL", "INFO").upper()
+
+
+class LoggingManager:
+    def __init__(self, level=DEFAULT_LEVEL):
+        self.logger = logging.getLogger("prompt_ops")
+        if not self.logger.handlers:
+            handler = logging.StreamHandler()
+            fmt = "%(asctime)s | %(levelname)-7s | %(message)s"
+            handler.setFormatter(logging.Formatter(fmt))
+            self.logger.addHandler(handler)
+        self.set_level(level)
+
+        self.timings: dict[str, float] = {}
+        self.metrics: list[dict] = []
+
+        atexit.register(self._dump_timings)  # convenience during CLI runs
+
+    def __del__(self):
+        # Unregister the atexit handler to prevent issues in testing
+        atexit.unregister(self._dump_timings)
+
+    # ---- configuration --------------------------------------------------
+    def set_level(self, level: str):
+        self.logger.setLevel(level.upper())
+
+    # ---- phase tracking --------------------------------------------------
+    def start_phase(self, name: str):
+        self.timings[name] = -time.perf_counter()
+
+    def end_phase(self, name: str):
+        if name not in self.timings:
+            return
+        self.timings[name] += time.perf_counter()
+        self.logger.info(f"[{name}] completed in {self.timings[name]:.2f}s")
+
+    @contextmanager
+    def phase(self, name):
+        self.start_phase(name)
+        try:
+            yield
+        finally:
+            self.end_phase(name)
+
+    # ---- progress + metrics ---------------------------------------------
+    def progress(self, msg: str, level: str = "INFO"):
+        getattr(self.logger, level.lower())(msg)
+
+    def log_metric(self, key: str, value, step: int | None = None):
+        rec = {"key": key, "value": value, "step": step, "time": time.time()}
+        self.metrics.append(rec)
+        self.logger.debug(f"[metric] {key}={value} step={step}")
+
+    # ---- export ----------------------------------------------------------
+    def export_json(self, path: str):
+        with open(path, "w") as f:
+            json.dump({"timings": self.timings, "metrics": self.metrics}, f, indent=2)
+
+    def _dump_timings(self):
+        # Called at program exit for insight in CLI runs
+        if not self.timings:
+            return
+        self.logger.info("=== Timings summary ===")
+        for k, v in self.timings.items():
+            self.logger.info(f"{k:<25} {v:6.2f}s")
+
+
+def get_logger() -> LoggingManager:
+    global _LOG_SINGLETON
+    if _LOG_SINGLETON is None:
+        _LOG_SINGLETON = LoggingManager()
+    return _LOG_SINGLETON

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -1,0 +1,99 @@
+import json
+import logging
+import os
+import time
+from unittest.mock import mock_open, patch
+
+import pytest
+
+from llama_prompt_ops.core.utils.logging import LoggingManager, get_logger
+
+
+@pytest.fixture(autouse=True)
+def reset_singleton():
+    """Reset the logger singleton before each test."""
+    # This is a bit of a hack to reset the singleton for isolated tests
+    import llama_prompt_ops.core.utils.logging
+
+    llama_prompt_ops.core.utils.logging._LOG_SINGLETON = None
+
+
+def test_get_logger_singleton():
+    """Test that get_logger returns a singleton instance."""
+    logger1 = get_logger()
+    logger2 = get_logger()
+    assert logger1 is logger2
+
+
+def test_logging_level(caplog):
+    """Test that the logging level is set correctly."""
+    logger = get_logger()
+    logger.set_level("DEBUG")
+
+    with caplog.at_level(logging.DEBUG):
+        logger.progress("debug message", level="DEBUG")
+        logger.progress("info message", level="INFO")
+
+    assert "debug message" in caplog.text
+    assert "info message" in caplog.text
+
+    caplog.clear()
+
+    logger.set_level("INFO")
+    with caplog.at_level(logging.INFO):
+        logger.progress("debug message", level="DEBUG")
+        logger.progress("info message", level="INFO")
+
+    assert "debug message" not in caplog.text
+    assert "info message" in caplog.text
+
+
+def test_phase_timing():
+    """Test the phase timing context manager."""
+    logger = get_logger()
+
+    with logger.phase("test_phase"):
+        time.sleep(0.01)
+
+    assert "test_phase" in logger.timings
+    assert logger.timings["test_phase"] > 0
+
+
+def test_log_metric():
+    """Test that metrics are logged correctly."""
+    logger = get_logger()
+    logger.log_metric("accuracy", 0.95, step=1)
+
+    assert len(logger.metrics) == 1
+    metric = logger.metrics[0]
+    assert metric["key"] == "accuracy"
+    assert metric["value"] == 0.95
+    assert metric["step"] == 1
+
+
+@patch("atexit.register")
+def test_export_json(mock_atexit_register):
+    """Test exporting timings and metrics to a JSON file."""
+    logger = get_logger()
+    logger.start_phase("export_phase")
+    time.sleep(0.01)
+    logger.end_phase("export_phase")
+    logger.log_metric("loss", 0.1)
+
+    m = mock_open()
+    with patch("builtins.open", m):
+        logger.export_json("test_log.json")
+
+    m.assert_called_once_with("test_log.json", "w")
+
+    # Get the content that was written to the file
+    handle = m()
+    # Join all the calls to write to reconstruct the JSON string
+    written_content = "".join(call.args[0] for call in handle.write.call_args_list)
+    data = json.loads(written_content)
+
+    assert "timings" in data
+    assert "export_phase" in data["timings"]
+    assert "metrics" in data
+    assert len(data["metrics"]) == 1
+    assert data["metrics"][0]["key"] == "loss"


### PR DESCRIPTION
Implements a new logging framework to provide better visibility into the prompt optimization process.

- Adds a LoggingManager class for centralized logging, timing, and metric tracking.
- Replaces print statements in core modules with the new logger.
- Adds a --log-level CLI option and YAML configuration for verbosity control.
- Adds documentation for the new logging features.
- Includes unit tests for the new logging module.


# What does this PR do?
This pull request introduces a new logging framework to improve the observability of the `llama-prompt-ops` tool, addressing Issue #18.

### Key Changes

-   **Centralized Logging**: A new `LoggingManager` class has been added to `src/llama_prompt_ops/core/utils/logging.py` to handle all logging, phase timing, and metric tracking in a centralized manner.
-   **Replaced `print` statements**: All `print` statements in the core modules (`migrator.py`, `model.py`, `metrics.py`, and `prompt_processors.py`) have been replaced with calls to the new logger.
-   **Configurable Verbosity**: The logging level can now be configured via the `--log-level` option in the CLI or through a `logging` section in the `config.yaml` file.
-   **Telemetry Export**: The framework can export detailed timings and metrics to a JSON file for analysis.
-   **Documentation**: Added documentation for the new logging features in `docs/advanced/logging.md`.
-   **Unit Tests**: Unit tests have been added in `tests/unit/test_logging.py` to ensure the new logging framework is working correctly.

This new framework provides a more robust and flexible way to monitor the prompt optimization process, making it easier to debug and analyze the performance of different strategies.


[//]: # (If resolving an issue, uncomment and update the line below)
[//]: # (Closes #18)

## Test Plan
### 1. Unit Tests

Unit tests for the new `LoggingManager` were added in `tests/unit/test_logging.py`. These tests cover the following functionality:

-   **Singleton Pattern**: Ensures that `get_logger()` always returns the same instance.
-   **Logging Levels**: Verifies that the logger correctly filters messages based on the configured logging level (`DEBUG`, `INFO`, etc.).
-   **Phase Timing**: Confirms that the `phase` context manager correctly measures the duration of code blocks.
-   **Metric Logging**: Checks that metrics are correctly logged and stored.
-   **JSON Export**: Validates that the logger can correctly export timings and metrics to a JSON file.

**To run the unit tests:**

```bash
$env:PYTHONPATH="src/"; pytest tests/unit/test_logging.py
```

**Expected Result:** All 5 tests should pass.

### 2. Unit Test Results:
```bash
============================================================================================================================================= test session starts ==============================================================================================================================================
platform win32 -- Python 3.11.4, pytest-7.3.1, pluggy-1.0.0
benchmark: 4.0.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: D:\Meta\llama-prompt-ops
plugins: anyio-4.8.0, asyncio-0.21.0, benchmark-4.0.0, cov-4.0.0, integration-0.2.3, mock-3.10.0, recording-0.12.2
asyncio: mode=Mode.STRICT
collected 5 items                                                                                                                                                                                                                                                                                               

tests\unit\test_logging.py .....                                                                                                                                                                                                                                                                          [100%]

=============================================================================================================================================== warnings summary ===============================================================================================================================================
C:\Users\siddh\AppData\Roaming\Python\Python311\site-packages\pydantic\_internal\_config.py:295
  C:\Users\siddh\AppData\Roaming\Python\Python311\site-packages\pydantic\_internal\_config.py:295: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.10/migration/
    warnings.warn(DEPRECATION_MESSAGE, DeprecationWarning)

C:\Users\siddh\AppData\Roaming\Python\Python311\site-packages\litellm\utils.py:165
  C:\Users\siddh\AppData\Roaming\Python\Python311\site-packages\litellm\utils.py:165: DeprecationWarning: open_text is deprecated. Use files() instead. Refer to https://importlib-resources.readthedocs.io/en/latest/using.html#migrating-from-legacy for migration advice.
    with resources.open_text(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================================================================================================== 5 passed, 2 warnings in 3.84s =========================================================================================================================================
--- Logging error ---
Traceback (most recent call last):
  File "C:\Python311\Lib\logging\__init__.py", line 1113, in emit
    stream.write(msg + self.terminator)
ValueError: I/O operation on closed file.
Call stack:
  File "D:\Meta\llama-prompt-ops\src\llama_prompt_ops\core\utils\logging.py", line 72, in _dump_timings
    self.logger.info("=== Timings summary ===")
Message: '=== Timings summary ==='
Arguments: ()
--- Logging error ---
Traceback (most recent call last):
  File "C:\Python311\Lib\logging\__init__.py", line 1113, in emit
    stream.write(msg + self.terminator)
ValueError: I/O operation on closed file.
Call stack:
  File "D:\Meta\llama-prompt-ops\src\llama_prompt_ops\core\utils\logging.py", line 74, in _dump_timings
    self.logger.info(f"{k:<25} {v:6.2f}s")
Message: 'test_phase                  0.01s'
Arguments: ()
```


### 3. End-to-End Manual Test

A manual end-to-end test was performed to ensure the logging framework integrates correctly with the `migrate` command.

**To reproduce the test:**

1.  Create a sample project:
    ```bash
    llama-prompt-ops create my-test-project
    ```
2.  Navigate into the project directory:
    ```bash
    cd my-test-project
    ```
3.  Add your API key to the `.env` file.
4.  Run the `migrate` command with `DEBUG` log level:
    ```bash
    llama-prompt-ops migrate --log-level DEBUG
    ```

**Expected Result:** The `migrate` command should run successfully, and the console output should display `DEBUG` and `INFO` level log messages, including phase timings. The optimization results should be saved to the `results` directory as expected.

[//]: # (## Documentation)
