### PR TITLE
feat: Validate minimum number of records in dataset file

### DIFF
--- a/src/llama_prompt_ops/interfaces/cli.py
+++ b/src/llama_prompt_ops/interfaces/cli.py
@@ -799,7 +799,7 @@ def migrate(config, model, output_dir, save_yaml, api_key_env, dotenv_path, log_
     except ValueError as e:
         click.echo(f"Error: {str(e)}", err=True)
         sys.exit(1)
-    
+
     # Validate the minimum number of records in dataset
     try:
         validate_min_records_in_dataset(dataset_adapter)

--- a/tests/integration/test_cli_integration.py
+++ b/tests/integration/test_cli_integration.py
@@ -131,6 +131,7 @@ class TestCLIIntegration:
                 "llama_prompt_ops.interfaces.cli.get_strategy", return_value=MagicMock()
             ),
             patch("llama_prompt_ops.interfaces.cli.load_config", return_value={}),
+            patch("llama_prompt_ops.interfaces.cli.validate_min_records_in_dataset", return_value=None),
         ):
 
             # Run the migrate command
@@ -194,6 +195,7 @@ class TestCLIIntegration:
                 "llama_prompt_ops.interfaces.cli.get_strategy", return_value=MagicMock()
             ),
             patch("llama_prompt_ops.interfaces.cli.load_config", return_value={}),
+            patch("llama_prompt_ops.interfaces.cli.validate_min_records_in_dataset", return_value=None),
         ):
 
             # Run the migrate command with the real config
@@ -268,6 +270,7 @@ class TestCLIIntegration:
                     return_value=MagicMock(),
                 ),
                 patch("llama_prompt_ops.interfaces.cli.load_config", return_value={}),
+                patch("llama_prompt_ops.interfaces.cli.validate_min_records_in_dataset", return_value=None),
             ):
 
                 # Run the migrate command with the actual file output

--- a/tests/integration/test_cli_integration.py
+++ b/tests/integration/test_cli_integration.py
@@ -131,7 +131,10 @@ class TestCLIIntegration:
                 "llama_prompt_ops.interfaces.cli.get_strategy", return_value=MagicMock()
             ),
             patch("llama_prompt_ops.interfaces.cli.load_config", return_value={}),
-            patch("llama_prompt_ops.interfaces.cli.validate_min_records_in_dataset", return_value=None),
+            patch(
+                "llama_prompt_ops.interfaces.cli.validate_min_records_in_dataset",
+                return_value=None,
+            ),
         ):
 
             # Run the migrate command
@@ -195,7 +198,10 @@ class TestCLIIntegration:
                 "llama_prompt_ops.interfaces.cli.get_strategy", return_value=MagicMock()
             ),
             patch("llama_prompt_ops.interfaces.cli.load_config", return_value={}),
-            patch("llama_prompt_ops.interfaces.cli.validate_min_records_in_dataset", return_value=None),
+            patch(
+                "llama_prompt_ops.interfaces.cli.validate_min_records_in_dataset",
+                return_value=None,
+            ),
         ):
 
             # Run the migrate command with the real config
@@ -270,7 +276,10 @@ class TestCLIIntegration:
                     return_value=MagicMock(),
                 ),
                 patch("llama_prompt_ops.interfaces.cli.load_config", return_value={}),
-                patch("llama_prompt_ops.interfaces.cli.validate_min_records_in_dataset", return_value=None),
+                patch(
+                    "llama_prompt_ops.interfaces.cli.validate_min_records_in_dataset",
+                    return_value=None,
+                ),
             ):
 
                 # Run the migrate command with the actual file output

--- a/tests/unit/test_datasets.py
+++ b/tests/unit/test_datasets.py
@@ -163,3 +163,22 @@ def test_custom_split_ratios(mock_dataset_adapter):
     assert len(train) == 70
     assert len(val) == 20
     assert len(test) == 10
+
+
+def test_minimum_records_in_dataset(simple_data_file):
+    try:
+        from llama_prompt_ops.interfaces.cli import validate_min_records_in_dataset
+    except ImportError as e:
+        pytest.skip(f"Skipping test because module import failed: {str(e)}")
+
+    # Sample data file has just 2 records
+    temp_file, _ = simple_data_file
+
+    dataset_adapter = ConfigurableJSONAdapter(
+        dataset_path=temp_file.name,
+        input_field="question",
+        golden_output_field="answer",
+    )
+
+    with pytest.raises(ValueError, match="Dataset must contain at least 4 records"):
+        validate_min_records_in_dataset(dataset_adapter)


### PR DESCRIPTION
# What does this PR do?
* This PR validates the minimum number of records to be present in the dataset file.
* The dataset must contain at least 4 records to avoid runtime errors during optimization.
* This is because the data is split into 25% training, 25% validation, and 50% testing.

Closes #12 

## Test Plan
* Created a unit test for the case where the dataset contains fewer than 4 records. It fails with the error: `Dataset must contain at least 4 records`
* All the existing tests passes

[//]: # (## Documentation)
