### PR TITLE
feat: enhance model name retrieval in convert_json_to_yaml function

### DIFF
--- a/src/prompt_ops/core/utils/format_utils.py
+++ b/src/prompt_ops/core/utils/format_utils.py
@@ -86,7 +86,16 @@ def convert_json_to_yaml(
 
     # Add config section with task model and optimization info if available
     if task_model:
-        model_name = getattr(task_model, "model_name", str(task_model))
+        # Get model name from various possible locations depending on adapter type
+        # LiteLLMModelAdapter uses self.model_name
+        # DSPyModelAdapter uses self.kwargs["model"]
+        # TextGradModelAdapter uses self.kwargs["engine_name"]
+        model_name = (
+            getattr(task_model, "model_name", None)
+            or (task_model.kwargs.get("model") if hasattr(task_model, "kwargs") else None)
+            or (task_model.kwargs.get("engine_name") if hasattr(task_model, "kwargs") else None)
+            or str(task_model)
+        )
         yaml_content += "\n\nconfig:\n"
         yaml_content += f"  task_model: {model_name}\n"
 


### PR DESCRIPTION
# What does this PR do?
Improves model name retrieval in convert_json_to_yaml function to support multiple adapter types. Currently the output yaml file contains a badly-serialized object e.g. `task_model: <prompt_ops.core.model.DSPyModelAdapter object at 0x...>`

[//]: # (If resolving an issue, uncomment and update the line below)
[//]: # (Closes #[issue-number])

## Test Plan
Run the example project and check the yaml file. Look at the `task_model` field to confirm that it correctly shows the model used, e.g. `task_model: openrouter/meta-llama/llama-3.3-70b-instruct`.

[//]: # (## Documentation)
