### PR TITLE
Litellm

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,8 @@ Add your API key to the `.env` file:
 ```bash
 OPENROUTER_API_KEY=your_key_here
 ```
-You can get an OpenRouter API key by creating an account at [OpenRouter](https://openrouter.ai/). For more inference provider options, see [Inference Providers](./docs/inference_providers.md).
+
+prompt-ops uses LiteLLM as a unified API client. LiteLLM automatically detects the provider from your model name (e.g., `openrouter/model`, `groq/model`) and looks for the corresponding provider-specific environment variable (`OPENROUTER_API_KEY`, `GROQ_API_KEY`, etc.). For more inference provider options, see [Inference Providers](./docs/inference_providers.md).
 
 ### Step 4: Run Optimization
 The optimization will take about 5 minutes.

--- a/configs/facility-simple.yaml
+++ b/configs/facility-simple.yaml
@@ -10,6 +10,7 @@ dataset:
   golden_output_field: "answer"
 
 # Model configuration (minimal required settings)
+# LiteLLM auto-detects API keys from provider-specific env vars (e.g., OPENROUTER_API_KEY)
 model:
   name: "openrouter/meta-llama/llama-3.3-70b-instruct"
   task_model: "openrouter/meta-llama/llama-3.3-70b-instruct"

--- a/configs/facility.yaml
+++ b/configs/facility.yaml
@@ -1,12 +1,9 @@
 # Facility dataset configuration for prompt optimization
 
-#TODO: think if there are any way to abstract this
-# provider: openrouter/hosted_vllm/togethercomputer
-# model: meta-llama/llama-3.3-70b-instruct
-# litellm
+# Model configuration - uses LiteLLM with provider prefix
+# LiteLLM auto-detects API key from provider-specific env vars (e.g., OPENROUTER_API_KEY, GROQ_API_KEY)
 model:
   name: "openrouter/meta-llama/llama-3.3-70b-instruct"
-  api_base: "https://openrouter.ai/api/v1" # rename base_url:
   temperature: 0.0
   # max_tokens: 2048       # Maximum number of tokens to generate
   # top_p: 0.9             # Nucleus sampling parameter

--- a/configs/hotpotqa.yaml
+++ b/configs/hotpotqa.yaml
@@ -1,6 +1,5 @@
 model:
   name: "openrouter/meta-llama/llama-3.1-8b-instruct"
-  api_base: "https://openrouter.ai/api/v1"
   temperature: 0.0
   max_tokens: 40960
 

--- a/docs/inference_providers.md
+++ b/docs/inference_providers.md
@@ -9,26 +9,29 @@ In prompt-ops, model configuration is specified in the `model` section of your Y
 ```yaml
 model:
   name: "openrouter/meta-llama/llama-3.1-8b-instruct"
-  api_base: "https://openrouter.ai/api/v1"
   temperature: 0.0
   max_tokens: 40960
 ```
 
-This configuration uses OpenRouter as the inference provider. Behind the scenes, prompt-ops uses LiteLLM to handle the API calls, which provides a unified interface to various LLM providers.
+**prompt-ops uses [LiteLLM](https://docs.litellm.ai/docs/) as the unified API client** to handle all LLM API calls. LiteLLM provides automatic provider detection based on the model name prefix (e.g., `openrouter/`, `groq/`, `together_ai/`) and looks for the corresponding environment variable (e.g., `OPENROUTER_API_KEY`, `GROQ_API_KEY`, `TOGETHERAI_API_KEY`).
 
 ## Available Inference Providers
 
-### 1. OpenRouter (Default)
+### 1. OpenRouter
 
-[OpenRouter](https://openrouter.ai/) provides access to a wide range of models from different providers through a unified API. This is the default configuration in prompt-ops.
+[OpenRouter](https://openrouter.ai/) provides access to a wide range of models from different providers through a unified API.
 
 ```yaml
 model:
   name: "openrouter/meta-llama/llama-3.1-8b-instruct"
-  api_base: "https://openrouter.ai/api/v1"
-  api_key: "${OPENROUTER_API_KEY}"  # Set via environment variable
   temperature: 0.0
   max_tokens: 40960
+```
+
+Set your API key as an environment variable (LiteLLM will auto-detect it):
+
+```bash
+export OPENROUTER_API_KEY=your_openrouter_api_key_here
 ```
 
 ### 2. vLLM
@@ -86,8 +89,6 @@ docker run -it --rm --name=nim \
 ```yaml
 model:
   name: "together_ai/meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8"
-  api_base: "https://api.together.xyz/v1"
-  api_key: "${TOGETHER_API_KEY}"
   temperature: 0.0
   max_tokens: 4096
 ```
@@ -96,16 +97,16 @@ To use Together AI, you'll need to:
 
 1. Sign up for an account at [Together AI](https://www.together.ai/)
 2. Generate an API key from your account dashboard
-3. Set the API key as an environment variable:
+3. Set the API key as an environment variable (LiteLLM will auto-detect it):
 
 ```bash
-export TOGETHER_API_KEY=your_api_key_here
+export TOGETHERAI_API_KEY=your_api_key_here
 ```
 
 Then run the optimization:
 
 ```bash
-prompt-ops migrate --api-key-env TOGETHER_API_KEY
+prompt-ops migrate
 ```
 
 ### 5. Groq
@@ -125,7 +126,7 @@ export GROQ_API_KEY=your_api_key_here
 Then run the optimization:
 
 ```bash
-prompt-ops migrate --api-key-env GROQ_API_KEY
+prompt-ops migrate
 ```
 
 ## Advanced Configuration
@@ -148,15 +149,15 @@ model:
 To run prompt-ops with your configuration:
 
 ```bash
-# With OpenRouter
-export OPENROUTER_API_KEY=your_api_key_here
-prompt-ops migrate --config configs/hotpotqa_openrouter.yaml
+# Set your provider-specific API key
+export OPENROUTER_API_KEY=your_key  # For OpenRouter models (openrouter/...)
+export GROQ_API_KEY=your_key        # For Groq models (groq/...)
+export TOGETHERAI_API_KEY=your_key  # For Together AI models (together_ai/...)
 
-# With vLLM (after starting the vLLM server)
-prompt-ops migrate --config configs/hotpotqa_vllm.yaml
-
-# With NVIDIA NIMs (after starting the NIM container)
-prompt-ops migrate --config configs/hotpotqa_nim.yaml
+# Run with any configuration
+prompt-ops migrate --config configs/your_config.yaml
 ```
 
-For more information on other model provider configuration options, refer to the [LiteLLM documentation](https://docs.litellm.ai/docs/).
+**How LiteLLM Works:** LiteLLM automatically detects the provider from your model name prefix (e.g., `openrouter/model`, `groq/model`, `together_ai/model`) and looks for the corresponding environment variable (`OPENROUTER_API_KEY`, `GROQ_API_KEY`, `TOGETHERAI_API_KEY`). No manual API routing required!
+
+For more information on supported providers, environment variables, and configuration options, refer to the [LiteLLM documentation](https://docs.litellm.ai/docs/set_keys).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ dependencies = [
     "python-dotenv>=1.0.0",
     "pyyaml>=6.0.0",
     "tiktoken>=0.9.0",
-    "openai>=1.65.0",
     "litellm>=1.63.0",
     "huggingface-hub>=0.29.0",
     "datasets>=2.21.0",

--- a/src/prompt_ops/core/model.py
+++ b/src/prompt_ops/core/model.py
@@ -12,6 +12,7 @@ It leverages LiteLLM's unified interface for accessing various LLM providers.
 """
 
 import os
+import time
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional, Union
 
@@ -132,6 +133,7 @@ class DSPyModelAdapter(ModelAdapter):
         max_tokens: int = 48000,
         temperature: float = 0.0,
         cache: bool = False,
+        num_retries: int = 15,
         **kwargs,
     ):
         """
@@ -144,6 +146,7 @@ class DSPyModelAdapter(ModelAdapter):
             max_tokens: Maximum number of tokens to generate
             temperature: Sampling temperature
             cache: Whether to cache responses
+            num_retries: Number of retries for rate limit errors with exponential backoff (default: 15)
             **kwargs: Additional arguments to pass to dspy.LM
         """
         if not DSPY_AVAILABLE:
@@ -162,7 +165,7 @@ class DSPyModelAdapter(ModelAdapter):
             **kwargs,
         }
 
-        # Create the DSPy model
+        # Create the DSPy model - pass num_retries directly to dspy.LM
         self._model = dspy.LM(
             model=model_name,
             api_base=api_base,
@@ -170,6 +173,7 @@ class DSPyModelAdapter(ModelAdapter):
             max_tokens=max_tokens,
             temperature=temperature,
             cache=cache,
+            num_retries=num_retries,
             **kwargs,
         )
 
@@ -206,7 +210,12 @@ class DSPyModelAdapter(ModelAdapter):
 
         Returns:
             The generated text response
+            
+        Raises:
+            litellm.exceptions.RateLimitError: If rate limit is exceeded after retries
         """
+        logger = get_logger()
+        
         # Create a temporary configuration with override parameters if provided
         temp_config = {}
         if temperature is not None:
@@ -214,14 +223,23 @@ class DSPyModelAdapter(ModelAdapter):
         if max_tokens is not None:
             temp_config["max_tokens"] = max_tokens
 
-        # Use the model to generate a completion
-        if temp_config:
-            with dspy.settings(**temp_config):
+        try:
+            # Use the model to generate a completion
+            if temp_config:
+                with dspy.settings(**temp_config):
+                    response = self._model(prompt)
+            else:
                 response = self._model(prompt)
-        else:
-            response = self._model(prompt)
 
-        return response
+            return response
+            
+        except Exception as e:
+            # Check if it's a rate limit error
+            if LITELLM_AVAILABLE and isinstance(e, litellm.exceptions.RateLimitError):
+                logger.error(f"Rate limit exceeded in generate(): {e}")
+            else:
+                logger.error(f"Error in generate(): {e}")
+            raise
 
     def generate_with_chat_format(
         self,
@@ -387,6 +405,8 @@ class LiteLLMModelAdapter(ModelAdapter):
         api_key: str = None,
         max_tokens: int = 4096,
         temperature: float = 0.0,
+        max_retries: int = 5,
+        retry_delay: float = 1.0,
         **kwargs,
     ):
         """
@@ -399,6 +419,8 @@ class LiteLLMModelAdapter(ModelAdapter):
             api_key: The API key (optional, LiteLLM reads from provider-specific env vars like OPENROUTER_API_KEY)
             max_tokens: Maximum number of tokens to generate
             temperature: Sampling temperature
+            max_retries: Maximum number of retries for rate limit errors (default: 5)
+            retry_delay: Initial delay in seconds for exponential backoff (default: 1.0)
             **kwargs: Additional arguments to pass to litellm.completion
         """
         if not LITELLM_AVAILABLE:
@@ -412,7 +434,55 @@ class LiteLLMModelAdapter(ModelAdapter):
         self.api_key = api_key
         self.max_tokens = max_tokens
         self.temperature = temperature
+        self.max_retries = max_retries
+        self.retry_delay = retry_delay
         self.kwargs = kwargs
+        self.logger = get_logger()
+
+    def _call_with_retry(self, litellm_kwargs: Dict[str, Any]) -> str:
+        """
+        Call LiteLLM completion with retry logic for rate limit errors.
+        
+        Args:
+            litellm_kwargs: Arguments to pass to litellm.completion
+            
+        Returns:
+            The generated text response
+            
+        Raises:
+            Exception: If all retries are exhausted or a non-retryable error occurs
+        """
+        last_exception = None
+        
+        for attempt in range(self.max_retries + 1):
+            try:
+                response = litellm.completion(**litellm_kwargs)
+                return response.choices[0].message.content
+                
+            except litellm.exceptions.RateLimitError as e:
+                last_exception = e
+                
+                if attempt < self.max_retries:
+                    # Exponential backoff: 1s, 2s, 4s, 8s, 16s...
+                    delay = self.retry_delay * (2 ** attempt)
+                    self.logger.warning(
+                        f"Rate limit hit (attempt {attempt + 1}/{self.max_retries + 1}). "
+                        f"Retrying in {delay:.1f}s..."
+                    )
+                    time.sleep(delay)
+                else:
+                    self.logger.error(
+                        f"Rate limit error: All {self.max_retries + 1} attempts exhausted."
+                    )
+                    raise
+                    
+            except Exception as e:
+                # For non-rate-limit errors, fail immediately
+                self.logger.error(f"API call failed: {str(e)}")
+                raise
+        
+        # Should never reach here, but just in case
+        raise last_exception if last_exception else Exception("Unknown error in retry logic")
 
     def generate(
         self, prompt: str, temperature: float = None, max_tokens: int = None, **kwargs
@@ -457,15 +527,8 @@ class LiteLLMModelAdapter(ModelAdapter):
         if self.api_base:
             litellm_kwargs["api_base"] = self.api_base
 
-        try:
-            response = litellm.completion(**litellm_kwargs)
-
-            # Extract text from response
-            return response.choices[0].message.content
-
-        except Exception as e:
-            # Convert to our standard error types if needed
-            raise e
+        # Use retry logic for rate limit handling
+        return self._call_with_retry(litellm_kwargs)
 
     def generate_with_chat_format(
         self,
@@ -511,15 +574,8 @@ class LiteLLMModelAdapter(ModelAdapter):
         if self.api_base:
             litellm_kwargs["api_base"] = self.api_base
 
-        try:
-            response = litellm.completion(**litellm_kwargs)
-
-            # Extract text from response
-            return response.choices[0].message.content
-
-        except Exception as e:
-            # Convert to our standard error types if needed
-            raise e
+        # Use retry logic for rate limit handling
+        return self._call_with_retry(litellm_kwargs)
 
 
 def setup_model(model_name=None, adapter_type="dspy", **kwargs):

--- a/src/prompt_ops/core/model.py
+++ b/src/prompt_ops/core/model.py
@@ -279,7 +279,7 @@ class TextGradModelAdapter(ModelAdapter):
         Initialize the TextGrad model adapter with configuration parameters.
 
         Args:
-            model_name: The model identifier (e.g., "openrouter/meta-llama/llama-3.3-70b-instruct")
+            model_name: The model identifier with provider prefix (e.g., "openrouter/meta-llama/llama-3.3-70b-instruct")
             api_base: The API base URL
             api_key: The API key
             **kwargs: Additional arguments to pass to tg.get_engine
@@ -393,9 +393,10 @@ class LiteLLMModelAdapter(ModelAdapter):
         Initialize the LiteLLM model adapter with configuration parameters.
 
         Args:
-            model_name: The model identifier (e.g., "openrouter/meta-llama/llama-3.3-70b-instruct")
-            api_base: The API base URL
-            api_key: The API key
+            model_name: The model identifier with provider prefix (e.g., "openrouter/meta-llama/llama-3.3-70b-instruct")
+                       LiteLLM auto-detects the provider and uses the appropriate API key from environment
+            api_base: The API base URL (optional, LiteLLM uses provider defaults)
+            api_key: The API key (optional, LiteLLM reads from provider-specific env vars like OPENROUTER_API_KEY)
             max_tokens: Maximum number of tokens to generate
             temperature: Sampling temperature
             **kwargs: Additional arguments to pass to litellm.completion
@@ -412,36 +413,6 @@ class LiteLLMModelAdapter(ModelAdapter):
         self.max_tokens = max_tokens
         self.temperature = temperature
         self.kwargs = kwargs
-
-        # Set up environment variables for LiteLLM if needed
-        if api_key:
-            self._setup_api_key(model_name, api_key)
-        if api_base:
-            self._setup_api_base(model_name, api_base)
-
-    def _setup_api_key(self, model_name: str, api_key: str):
-        """Set appropriate environment variable based on model provider."""
-        model_lower = model_name.lower() if model_name else ""
-
-        if "openai" in model_lower and "openrouter" not in model_lower:
-            os.environ["OPENAI_API_KEY"] = api_key
-        elif "anthropic" in model_lower or "claude" in model_lower:
-            os.environ["ANTHROPIC_API_KEY"] = api_key
-        elif "openrouter" in model_lower:
-            os.environ["OPENROUTER_API_KEY"] = api_key
-        elif "together" in model_lower:
-            os.environ["TOGETHER_API_KEY"] = api_key
-        # Add more providers as needed
-
-    def _setup_api_base(self, model_name: str, api_base: str):
-        """Set appropriate base URL environment variable."""
-        model_lower = model_name.lower() if model_name else ""
-
-        if "openai" in model_lower and "openrouter" not in model_lower:
-            os.environ["OPENAI_API_BASE"] = api_base
-        elif "openrouter" in model_lower:
-            os.environ["OPENROUTER_API_BASE"] = api_base
-        # Add more as needed
 
     def generate(
         self, prompt: str, temperature: float = None, max_tokens: int = None, **kwargs

--- a/src/prompt_ops/core/model.py
+++ b/src/prompt_ops/core/model.py
@@ -210,12 +210,12 @@ class DSPyModelAdapter(ModelAdapter):
 
         Returns:
             The generated text response
-            
+
         Raises:
             litellm.exceptions.RateLimitError: If rate limit is exceeded after retries
         """
         logger = get_logger()
-        
+
         # Create a temporary configuration with override parameters if provided
         temp_config = {}
         if temperature is not None:
@@ -232,7 +232,7 @@ class DSPyModelAdapter(ModelAdapter):
                 response = self._model(prompt)
 
             return response
-            
+
         except Exception as e:
             # Check if it's a rate limit error
             if LITELLM_AVAILABLE and isinstance(e, litellm.exceptions.RateLimitError):
@@ -442,29 +442,29 @@ class LiteLLMModelAdapter(ModelAdapter):
     def _call_with_retry(self, litellm_kwargs: Dict[str, Any]) -> str:
         """
         Call LiteLLM completion with retry logic for rate limit errors.
-        
+
         Args:
             litellm_kwargs: Arguments to pass to litellm.completion
-            
+
         Returns:
             The generated text response
-            
+
         Raises:
             Exception: If all retries are exhausted or a non-retryable error occurs
         """
         last_exception = None
-        
+
         for attempt in range(self.max_retries + 1):
             try:
                 response = litellm.completion(**litellm_kwargs)
                 return response.choices[0].message.content
-                
+
             except litellm.exceptions.RateLimitError as e:
                 last_exception = e
-                
+
                 if attempt < self.max_retries:
                     # Exponential backoff: 1s, 2s, 4s, 8s, 16s...
-                    delay = self.retry_delay * (2 ** attempt)
+                    delay = self.retry_delay * (2**attempt)
                     self.logger.warning(
                         f"Rate limit hit (attempt {attempt + 1}/{self.max_retries + 1}). "
                         f"Retrying in {delay:.1f}s..."
@@ -475,14 +475,18 @@ class LiteLLMModelAdapter(ModelAdapter):
                         f"Rate limit error: All {self.max_retries + 1} attempts exhausted."
                     )
                     raise
-                    
+
             except Exception as e:
                 # For non-rate-limit errors, fail immediately
                 self.logger.error(f"API call failed: {str(e)}")
                 raise
-        
+
         # Should never reach here, but just in case
-        raise last_exception if last_exception else Exception("Unknown error in retry logic")
+        raise (
+            last_exception
+            if last_exception
+            else Exception("Unknown error in retry logic")
+        )
 
     def generate(
         self, prompt: str, temperature: float = None, max_tokens: int = None, **kwargs

--- a/src/prompt_ops/core/utils/format_utils.py
+++ b/src/prompt_ops/core/utils/format_utils.py
@@ -86,7 +86,16 @@ def convert_json_to_yaml(
 
     # Add config section with task model and optimization info if available
     if task_model:
-        model_name = getattr(task_model, "model_name", str(task_model))
+        # Get model name from various possible locations depending on adapter type
+        # LiteLLMModelAdapter uses self.model_name
+        # DSPyModelAdapter uses self.kwargs["model"]
+        # TextGradModelAdapter uses self.kwargs["engine_name"]
+        model_name = (
+            getattr(task_model, "model_name", None)
+            or (task_model.kwargs.get("model") if hasattr(task_model, "kwargs") else None)
+            or (task_model.kwargs.get("engine_name") if hasattr(task_model, "kwargs") else None)
+            or str(task_model)
+        )
         yaml_content += "\n\nconfig:\n"
         yaml_content += f"  task_model: {model_name}\n"
 

--- a/src/prompt_ops/core/utils/format_utils.py
+++ b/src/prompt_ops/core/utils/format_utils.py
@@ -92,8 +92,16 @@ def convert_json_to_yaml(
         # TextGradModelAdapter uses self.kwargs["engine_name"]
         model_name = (
             getattr(task_model, "model_name", None)
-            or (task_model.kwargs.get("model") if hasattr(task_model, "kwargs") else None)
-            or (task_model.kwargs.get("engine_name") if hasattr(task_model, "kwargs") else None)
+            or (
+                task_model.kwargs.get("model")
+                if hasattr(task_model, "kwargs")
+                else None
+            )
+            or (
+                task_model.kwargs.get("engine_name")
+                if hasattr(task_model, "kwargs")
+                else None
+            )
             or str(task_model)
         )
         yaml_content += "\n\nconfig:\n"

--- a/src/prompt_ops/interfaces/cli.py
+++ b/src/prompt_ops/interfaces/cli.py
@@ -29,6 +29,7 @@ from dotenv import load_dotenv
 
 try:
     import litellm
+
     LITELLM_AVAILABLE = True
 except ImportError:
     LITELLM_AVAILABLE = False
@@ -74,27 +75,30 @@ def check_api_key(api_key_env, dotenv_path=".env"):
 
 def validate_litellm_environment(model_name):
     """Validate that the environment is properly configured for the model using LiteLLM.
-    
+
     Args:
         model_name: The full model name with provider prefix (e.g., "openrouter/model")
-    
+
     Returns:
         bool: True if environment is valid, False otherwise
     """
     if not LITELLM_AVAILABLE:
         return True  # Skip validation if litellm not available
-    
+
     try:
         # Use LiteLLM's validate_environment to check for required env vars
         result = litellm.validate_environment(model_name)
-        
+
         if result.get("keys_in_environment", False):
             click.echo(f"✓ Environment validated for model: {model_name}")
             return True
         else:
             missing_keys = result.get("missing_keys", [])
             if missing_keys:
-                click.echo(f"Warning: Missing environment variables: {', '.join(missing_keys)}", err=True)
+                click.echo(
+                    f"Warning: Missing environment variables: {', '.join(missing_keys)}",
+                    err=True,
+                )
                 click.echo(f"LiteLLM expects these for model '{model_name}'", err=True)
             return False
     except Exception as e:
@@ -155,20 +159,22 @@ def cli():
 def create(project_name, output_dir, model, api_key_env):
     """Create a new prompt optimization project with all necessary files."""
     project_dir = os.path.join(output_dir, project_name)
-    
+
     # Infer API key environment variable from model if not specified
     if not api_key_env:
-        provider = model.split('/')[0] if '/' in model else 'openai'
+        provider = model.split("/")[0] if "/" in model else "openai"
         provider_to_key = {
-            'openrouter': 'OPENROUTER_API_KEY',
-            'openai': 'OPENAI_API_KEY',
-            'anthropic': 'ANTHROPIC_API_KEY',
-            'groq': 'GROQ_API_KEY',
-            'cerebras': 'CEREBRAS_API_KEY',
-            'together': 'TOGETHER_API_KEY',
-            'cohere': 'COHERE_API_KEY',
+            "openrouter": "OPENROUTER_API_KEY",
+            "openai": "OPENAI_API_KEY",
+            "anthropic": "ANTHROPIC_API_KEY",
+            "groq": "GROQ_API_KEY",
+            "cerebras": "CEREBRAS_API_KEY",
+            "together": "TOGETHER_API_KEY",
+            "cohere": "COHERE_API_KEY",
         }
-        api_key_env = provider_to_key.get(provider.lower(), f'{provider.upper()}_API_KEY')
+        api_key_env = provider_to_key.get(
+            provider.lower(), f"{provider.upper()}_API_KEY"
+        )
 
     try:
         # Check if directory already exists
@@ -900,7 +906,10 @@ def migrate(config, model, output_dir, save_yaml, api_key_env, dotenv_path, log_
         validate_litellm_environment(task_model_name)
     except Exception as e:
         click.echo(f"Warning: Environment validation failed: {str(e)}", err=True)
-        click.echo("Continuing anyway - LiteLLM will error if credentials are actually missing.", err=True)
+        click.echo(
+            "Continuing anyway - LiteLLM will error if credentials are actually missing.",
+            err=True,
+        )
 
     # Create metric based on config - use task_model for metric
     try:

--- a/src/prompt_ops/interfaces/cli.py
+++ b/src/prompt_ops/interfaces/cli.py
@@ -209,7 +209,7 @@ def create(project_name, output_dir, model, api_key_env):
                 "strict_json": False,
                 "output_field": "answer",
             },
-            "optimization": {"strategy": "basic"},
+            "optimization": {"strategy": "basic", "num_threads": 2},
         }
 
         with open(os.path.join(project_dir, "config.yaml"), "w") as f:

--- a/use-cases/hotpotqa/README.md
+++ b/use-cases/hotpotqa/README.md
@@ -20,9 +20,12 @@ Make sure you have set up your API keys in the `.env` file at the root of the pr
 
 ```
 OPENROUTER_API_KEY=your_key_here
-# or
+# or other provider-specific keys
+GROQ_API_KEY=your_key_here
 HUGGINGFACE_API_KEY=your_key_here
 ```
+
+LiteLLM will automatically detect the correct API key based on your model name prefix (e.g., `openrouter/`, `groq/`).
 
 ### 3. Run Optimization
 

--- a/use-cases/hotpotqa/hotpotqa.yaml
+++ b/use-cases/hotpotqa/hotpotqa.yaml
@@ -1,6 +1,5 @@
 model:
   name: "openrouter/meta-llama/llama-3.1-8b-instruct"
-  api_base: "https://openrouter.ai/api/v1"
   temperature: 0.0
   max_tokens: 40960
 

--- a/use-cases/ms-marco-pdo/README.md
+++ b/use-cases/ms-marco-pdo/README.md
@@ -16,6 +16,7 @@ PDO (Prompt Duel Optimizer) is a dueling bandit optimization strategy that:
 1. **Set your API key** in a `.env` file in the project root:
    ```bash
    OPENROUTER_API_KEY=your_api_key_here
+   # LiteLLM auto-detects the provider from your model name (openrouter/model)
    ```
 
 2. **Run the optimization**:

--- a/use-cases/web-of-lies-pdo/README.md
+++ b/use-cases/web-of-lies-pdo/README.md
@@ -30,6 +30,7 @@ PDO (Prompt Duel Optimizer) is a dueling bandit optimization strategy that:
 1. **Set your API key** in a `.env` file in the project root:
    ```bash
    OPENROUTER_API_KEY=your_api_key_here
+   # LiteLLM auto-detects the provider from your model name (openrouter/model)
    ```
 
 2. **Run the optimization**:


### PR DESCRIPTION
# What does this PR do?
Migrates model callsites to use LiteLLM over OpenRouter, enabling convenient support of multiple LLM providers via LiteLLM's provider router structure.

[//]: # (If resolving an issue, uncomment and update the line below)
[//]: # (Closes #[issue-number])

## Test Plan
Tested prompt optimization runs using both Llama API (`task_model: meta_llama/Llama-3.3-70B-Instruct`) and OpenRouter (`task_model: openrouter/meta-llama/llama-3.3-70b-instruct`) providers, and confirmed that both runs used the correct model, provider and API key, as described in the updated documentation.

## Documentation
**prompt-ops** uses LiteLLM as a unified API client. LiteLLM automatically detects the provider from your model name (e.g., `openrouter/model`, `groq/model`) and looks for the corresponding provider-specific environment variable (`OPENROUTER_API_KEY`, `GROQ_API_KEY`, etc.). For more inference provider options, see [Inference Providers](./docs/inference_providers.md).
